### PR TITLE
Update geoip2 variables for ANS db

### DIFF
--- a/assets/tpls/etc/nginx/nginx.conf
+++ b/assets/tpls/etc/nginx/nginx.conf
@@ -57,7 +57,7 @@ http {
     }
     geoip2 /etc/nginx/geoip/GeoLite2-ASN.mmdb {
         auto_reload 5m;
-        $geoip2_data_org autonomousSystemOrganization;
+        $geoip2_data_org autonomous_system_organization;
     }
 
     ## Timeouts


### PR DESCRIPTION
Seems the ANS database has a different format now that whats specified in your nginx.conf file:
```
$ mmdblookup --file GeoLite2-ASN.mmdb --ip 62.11.0.0

  {
    "autonomous_system_number": 
      8612 <uint32>
    "autonomous_system_organization": 
      "Tiscali SpA" <utf8_string>
  }
```