### PR TITLE
Enable gzip for type application/javascript

### DIFF
--- a/assets/tpls/etc/nginx/nginx.conf
+++ b/assets/tpls/etc/nginx/nginx.conf
@@ -87,7 +87,7 @@ http {
     gzip_comp_level   1;
     gzip_http_version 1.1;
     gzip_min_length   10;
-    gzip_types        text/plain text/css application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
+    gzip_types        text/plain text/css application/javascript application/x-javascript text/xml application/xml application/xml+rss text/javascript image/x-icon application/vnd.ms-fontobject font/opentype application/x-font-ttf;
     gzip_vary         on;
     gzip_proxied      any;
     gzip_disable      "msie6";


### PR DESCRIPTION
This is the content type reported by matomo.js `content-type: application/javascript`