### PR TITLE
gzip all API calls

### DIFF
--- a/assets/tpls/etc/nginx/nginx.conf
+++ b/assets/tpls/etc/nginx/nginx.conf
@@ -146,11 +146,15 @@ http {
 
         ## only allow accessing the following php files
         location ~ ^/(index|matomo|piwik|js/index).php {
+            gzip_types "*"
+            charset UTF-8;
             fastcgi_pass unix:/var/run/php-fpm7.sock;
         }
 
         ## needed for HeatmapSessionRecording plugin
         location = /plugins/HeatmapSessionRecording/configs.php {
+            gzip_types "*"
+            charset UTF-8;
             fastcgi_pass unix:/var/run/php-fpm7.sock;
         }
 


### PR DESCRIPTION
With the current config some API calls won't be compressed. Force compression for all files for requests in the given location