### PR TITLE
fix owner of /var/www/matomo/vendor/tecnickcom/tcpdf/fonts

### DIFF
--- a/rootfs/etc/cont-init.d/02-fix-perms.sh
+++ b/rootfs/etc/cont-init.d/02-fix-perms.sh
@@ -23,7 +23,8 @@ chown matomo. \
   /data/tmp \
   /var/www/matomo/plugins \
   /var/www/matomo/matomo.js \
-  /var/www/matomo/piwik.js
+  /var/www/matomo/piwik.js \
+  /var/www/matomo/vendor/tecnickcom/tcpdf/fonts
 chown -R matomo. \
   /tpls \
   /var/lib/nginx \


### PR DESCRIPTION
Fixes #143 