### PR TITLE
chore: Matomo 5.2.2

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG MATOMO_VERSION=5.2.1
+ARG MATOMO_VERSION=5.2.2
 ARG ALPINE_VERSION=3.21
 
 FROM --platform=${BUILDPLATFORM} crazymax/alpine-s6:${ALPINE_VERSION}-2.2.0.3 AS download


### PR DESCRIPTION
Matomo 5.2.2 is a patch release that includes several  high-impact security fixes. These fixes are essential to maintaining the integrity and security of your analytics platform.