### PR TITLE
chore: upgrade matomo 5.3.0

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # syntax=docker/dockerfile:1
 
-ARG MATOMO_VERSION=5.2.2
+ARG MATOMO_VERSION=5.3.0
 ARG ALPINE_VERSION=3.21
 
 FROM --platform=${BUILDPLATFORM} crazymax/alpine-s6:${ALPINE_VERSION}-2.2.0.3 AS download


### PR DESCRIPTION
**Release notes**: https://matomo.org/changelog/matomo-5-3-0/

### Tickets closed in Matomo 5.3.0
**All Websites Dashboard**

- [#22312](https://github.com/matomo-org/matomo/pull/22312): Improve layout of the All Websites page. [by [@mneudert](https://github.com/mneudert)]

**Reporting**

- [#22849](https://github.com/matomo-org/matomo/pull/22849): Increase width of the Segments drop-down list. [by [@nathangavin](https://github.com/nathangavin)]
- [#22827](https://github.com/matomo-org/matomo/pull/22827): Report tables now include action icons (e.g., change visualisation, export, search) below the report title and not only at the end of the report. [by [@michalkleiner](https://github.com/michalkleiner)]
- [#23041](https://github.com/matomo-org/matomo/pull/23041): Super Users can now share user-specific segments without restricting the original owner’s ability to edit them. This update also improves the SegmentEditor API with enhanced type hinting and automatic sanitisation. [by [@sgiehl](https://github.com/sgiehl)]

**Privacy and Security**

- [#23017](https://github.com/matomo-org/matomo/pull/23017): When using the GDPR Tools to extract data, if a site with visitor logs or visitor profiles disabled is selected, the data is not available. [by [@nathangavin](https://github.com/nathangavin)]
- [#23068](https://github.com/matomo-org/matomo/pull/23068): The 2FA input field now uses autocomplete="one-time-code" and a new ID to prevent password managers from misidentifying it as a login field. [by [@sgiehl](https://github.com/sgiehl)]

**Performance and Archiving**

- [#22989](https://github.com/matomo-org/matomo/pull/22989): Allow invalidation of All Visits only and improvements to parts of the core:invalidate-report-data command. [by [@sgiehl](https://github.com/sgiehl)]
- [#22981](https://github.com/matomo-org/matomo/pull/22981): Store Hostname of archiving server in Invalidation Records. [by [@sgiehl](https://github.com/sgiehl)]
- [#23021](https://github.com/matomo-org/matomo/pull/23021): Adds a new command to allow administrators to reset stuck invalidations that are incorrectly marked as “in progress”. [by [@sgiehl](https://github.com/sgiehl)]
- [#23035](https://github.com/matomo-org/matomo/pull/23035): Automatically remove duplicate invalidations upon reset. [by [@sgiehl](https://github.com/sgiehl)]
- [#22979](https://github.com/matomo-org/matomo/pull/22979): Limit the processing time of archiving jobs. [by [@sgiehl](https://github.com/sgiehl)]
- [#22394](https://github.com/matomo-org/matomo/pull/22394): Prevent redundant double archiving of overlapping periods in multi-server setups. [by [@sgiehl](https://github.com/sgiehl)]

**Matomo Tag Manager (MTM)**

- [#943](https://github.com/matomo-org/tag-manager/pull/943): Tag Manager now supports additional tracking capabilities previously only available via direct JavaScript (_paq). [by [@AltamashShaikh](https://github.com/AltamashShaikh)]
- [#953](https://github.com/matomo-org/tag-manager/pull/953): Added a new {{FormElement}} to capture and interact with specific form elements. [by [@AltamashShaikh](https://github.com/AltamashShaikh)]
- [#967](https://github.com/matomo-org/tag-manager/pull/967): The Google Analytics 4 (GA4) tag has been replaced with the [Google tag (gtag.js)](https://matomo.org/faq/tag-manager/how-to-configure-the-google-tag-in-matomo-tag-manager/), ensuring compatibility with the latest tracking implementation. [by [@AltamashShaikh](https://github.com/AltamashShaikh)]
- [#972](https://github.com/matomo-org/tag-manager/pull/972): Updated reference check to include variables referencing variables. [by [@snake14](https://github.com/snake14)]
- [#958](https://github.com/matomo-org/tag-manager/pull/958): Fixed issue with missing array key at upgrade. [by [@mikkeschiren](https://github.com/mikkeschiren)]