### PR TITLE
require database config before treating Matomo as installed

### DIFF
--- a/rootfs/etc/cont-init.d/03-config.sh
+++ b/rootfs/etc/cont-init.d/03-config.sh
@@ -5,6 +5,10 @@ runas_user() {
   gosu matomo:matomo "$@"
 }
 
+has_database_config() {
+  [ -f "$1" ] && grep -q '^\[database\]' "$1"
+}
+
 TZ=${TZ:-UTC}
 MEMORY_LIMIT=${MEMORY_LIMIT:-256M}
 UPLOAD_MAX_SIZE=${UPLOAD_MAX_SIZE:-16M}
@@ -73,7 +77,10 @@ fi
 
 # Check config
 echo "Checking Matomo config..."
-if [ ! -f "/data/config/config.ini.php" ] && [ -f "/var/www/matomo/config/config.ini.php" ]; then
+if ! has_database_config "/data/config/config.ini.php" && has_database_config "/var/www/matomo/config/config.ini.php"; then
+  echo "Persisting Matomo config to /data/config/config.ini.php..."
+  runas_user cp "/var/www/matomo/config/config.ini.php" "/data/config/config.ini.php"
+elif [ ! -f "/data/config/config.ini.php" ] && [ -f "/var/www/matomo/config/config.ini.php" ]; then
   runas_user cp "/var/www/matomo/config/config.ini.php" "/data/config/config.ini.php"
 fi
 ln -sf "/data/config/config.ini.php" "/var/www/matomo/config/config.ini.php"

--- a/rootfs/etc/cont-init.d/04-svc-main.sh
+++ b/rootfs/etc/cont-init.d/04-svc-main.sh
@@ -10,7 +10,7 @@ fi
 LOG_LEVEL=${LOG_LEVEL:-WARN}
 
 # Check if already installed
-if [ -f "/data/config/config.ini.php" ]; then
+if [ -f "/data/config/config.ini.php" ] && grep -q '^\[database\]' "/data/config/config.ini.php"; then
   echo "Setting Matomo log level to $LOG_LEVEL..."
   console config:set --section=log --key=log_level --value="$LOG_LEVEL"
 

--- a/rootfs/usr/local/bin/matomo_archive
+++ b/rootfs/usr/local/bin/matomo_archive
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-if [ -f "/data/config/config.ini.php" ]; then
+if [ -f "/data/config/config.ini.php" ] && grep -q '^\[database\]' "/data/config/config.ini.php"; then
   echo "Starting Matomo archiving..."
   console config:set --section='General' --key='enable_browser_archiving_triggering' --value='0'
   console core:archive --no-interaction ${ARCHIVE_OPTIONS}


### PR DESCRIPTION
fixes https://github.com/crazy-max/docker-matomo/issues/174
fixes #177 

File existence was too weak as an installed-state signal because Matomo can leave a nearly empty config file during first-install persistence failure. Requiring database config matches the practical invariant needed before running Matomo console update and config commands.

The init scripts now require a `[database]` section before treating Matomo as installed or running archive commands. The config init script also persists a generated Matomo config from the application tree back into `/data` when the persisted config is missing the database section.